### PR TITLE
Fix chunk data reading issue

### DIFF
--- a/craftlib-protocol/src/main/kotlin/dev/zerite/craftlib/protocol/data/world/ByteNibbleArray.kt
+++ b/craftlib-protocol/src/main/kotlin/dev/zerite/craftlib/protocol/data/world/ByteNibbleArray.kt
@@ -28,7 +28,7 @@ data class ByteNibbleArray(var data: ByteArray, private val desired: Int = 16 * 
      * @author Koding
      * @since  0.1.0-SNAPSHOT
      */
-    operator fun get(index: Int, default: Int) = if (index < 0 || (index / 2) >= data.size - 1 || data.isEmpty()) default else this[index]
+    operator fun get(index: Int, default: Int) = if (index < 0 || (index / 2) >= data.size || data.isEmpty()) default else this[index]
 
     /**
      * Sets the data at the given index to the provided value.


### PR DESCRIPTION
[contributing]: https://github.com/Zerite/CraftLib/blob/master/.github/CONTRIBUTING.MD

#### Description
Fixes an issue with chunk data reading causing all fields backed by a nibble array to sometimes read incorrect values. This issue was caused by an out-of-bounds check making the last two values in a nibble array inaccessible.

#### Checklist
<!-- Ensure that your changes abide by the following guidelines -->

- [x] I have checked **any existing PRs** for new features.
- [x] I have read and abide by the [contributing guidelines][contributing].
- [x] There are **no similar features** already implemented.
- [x] This contains original code and is **not copied** from another project.
- [x] This code is final and complete.

#### Changes
<!-- Note which section(s) you've modified -->

- [x] Protocol
- [ ] Project Structure
- [ ] Documentation
