### PR TITLE
:pencil: Switch from deprecated feature "compile" to implementation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -40,7 +40,7 @@ sufficiently complete.
 
 **Gradle**
 ```groovy
-compile 'dev.zerite.craftlib:craftlib-protocol:0.1.1'
+implementation 'dev.zerite.craftlib:craftlib-protocol:0.1.1'
 ```
 
 #### 3. Special Thanks


### PR DESCRIPTION
[contributing]: https://github.com/Zerite/CraftLib/blob/master/.github/CONTRIBUTING.MD

#### Description
Switched the `compile` notation in the readme to `implementation`.

#### Checklist
<!-- Ensure that your changes abide by the following guidelines -->

- [x] I have checked **any existing PRs** for new features.
- [x] I have read and abide by the [contributing guidelines][contributing].
- [x] There are **no similar features** already implemented.
- [x] This contains original code and is **not copied** from another project.
- [x] This code is final and complete.

#### Changes
<!-- Note which section(s) you've modified -->

- [ ] Protocol
- [ ] Project Structure
- [x] Documentation
- [ ] Other: \______   <!-- Insert other type here -->
